### PR TITLE
Add page navigation with jump and resume

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -4,12 +4,17 @@ let currentIdx = 0;
 const cacheItems = {};      // idx -> item json
 
 /* ---------------- 初始化 ------------------ */
-window.addEventListener('DOMContentLoaded', () => {
-  loadItem(0);
-  document.addEventListener('keydown', onKey);
-  document.getElementById('quick-label').focus();
+window.addEventListener("DOMContentLoaded", () => {
+  const last = parseInt(localStorage.getItem("lastIdx")) || 0;
+  loadItem(Math.min(Math.max(last,0), TOTAL-1));
+  document.addEventListener("keydown", onKey);
+  document.getElementById("quick-label").focus();
+  document.getElementById("page-form").addEventListener("submit", e => {
+    e.preventDefault();
+    const val = parseInt(document.getElementById("page-input").value);
+    if(!isNaN(val)) loadItem(Math.min(Math.max(val-1,0), TOTAL-1));
+  });
 });
-
 /* ---------------- 資料載入 ---------------- */
 async function loadItem(idx) {
   if (cacheItems[idx]) {
@@ -25,6 +30,9 @@ async function loadItem(idx) {
 /* ---------------- 主渲染 ------------------ */
 function render(d) {
   currentIdx = d.idx;
+  document.getElementById("page-input").value = d.idx + 1;
+  document.getElementById("page-total").textContent = TOTAL;
+  localStorage.setItem("lastIdx", d.idx);
   document.getElementById('media-info').textContent = d.media_name;
 
   /* ── 左側媒體 ───────────────────────────*/

--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,7 @@
 /* ── 版面 ───────────────────────────────────────── */
 html,body{margin:0;height:100%;font-family:Arial,Helvetica,sans-serif;}
+#page-nav{position:fixed;top:0;left:50%;transform:translateX(-50%);background:rgba(0,0,0,.65);color:#fff;padding:4px 8px;font-size:14px;z-index:1000;}
+#page-nav input{width:60px;}
 #container{display:flex;height:100%;}
 /* 左側 ──────────────────────────────────────── */
 #left{flex:1;position:relative;display:flex;justify-content:center;align-items:center;background:#111;}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,11 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
+  <div id="page-nav">
+    <form id="page-form">
+      <input id="page-input" type="number" min="1" value="1"/> / <span id="page-total"></span>
+    </form>
+  </div>
   <div id="container">
     <div id="left">
       <div id="media-info"></div>
@@ -13,8 +18,8 @@
     </div>
 
    <div id="right">
-+    <!-- ★ system_label_meta_txt 會顯示在這裡 -->
-+    <h4 id="quick-name"></h4>
+    <!-- ★ system_label_meta_txt 會顯示在這裡 -->
+    <h4 id="quick-name"></h4>
      <div id="anno-area"></div>
      <textarea id="quick-label"
                placeholder="在此輸入快速標籤，按 → 儲存並下一張"></textarea>


### PR DESCRIPTION
## Summary
- add a top page navigation bar
- allow jumping to a specific page
- remember the last visited page using localStorage

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68431a3ab5108320aaed06b8a357637d