### PR TITLE
Add directory mode for group labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ source .venv/bin/activate
 pip install flask
 
 # 4. 啟動（假設資料集位於 /data/images）
-python app.py /data/images
+python app.py /data/images              # 一般檔案模式
+python app.py /data/images --dir        # 以資料夾為單位標註
+# 查看所有選項
+python app.py -h
 # 伺服器監聽 http://0.0.0.0:{port}
 ````
 
@@ -70,7 +73,8 @@ python app.py /data/images
 | ---- | --------------- | --------------------------------- |
 | 下一張  | → (Right Arrow) | 自動儲存當前標註 → 載入下一張                  |
 | 上一張  | ← (Left Arrow)  | 自動儲存 → 載入上一張                      |
-| 快速標籤 | 直接輸入英數字後按 →     | 建立 / 覆寫 `*.system_label_meta_txt` |
+| 快速標籤 | 直接輸入英數字後按 →     | 建立 / 覆寫 `*.system_label_meta_txt`<br>使用 `--dir` 時會寫入 `system_label_dir_meta_txt` |
+| 換資料夾 | ↑ / ↓ (Arrow Up/Down) | `--dir` 模式下，切換上一／下一資料夾 |
 | 編輯註解 | 右側 textarea     | 編輯完成後按 → 或 ← 立即儲存                 |
 
 ---

--- a/app.py
+++ b/app.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python
 """
 Dataset Annotator  (port 49145)
-啟動：python app.py /absolute/path/to/dataset
+啟動：python app.py <dataset_path> [--dir]
 """
 import sys, io, mimetypes
+import argparse
 from pathlib import Path
 from collections import defaultdict, OrderedDict
 from flask import Flask, request, jsonify, render_template, send_file, abort
+
+# ─── 啟動參數 ──────────────────────────────────────────────────────────
+parser = argparse.ArgumentParser(description='Simple dataset annotator')
+parser.add_argument('dataset_path', help='Path to dataset root')
+parser.add_argument('--dir', action='store_true',
+                    help='Label directories instead of individual files')
+cli_args = parser.parse_args()
 
 # ─── 常數 ──────────────────────────────────────────────────────────────
 IMAGE_EXTS   = {'.jpg', '.jpeg', '.png', '.webp', '.bmp', '.gif'}
@@ -14,13 +22,15 @@ VIDEO_EXTS   = {'.mp4', '.mov', '.avi', '.mkv'}
 AUDIO_EXTS   = {'.mp3', '.wav', '.ogg'}
 TEXT_EXTS    = {'.txt', '.csv', '.json', '.yaml', '.yml'}
 
-MEDIA_FILE_EXTS = IMAGE_EXTS | VIDEO_EXTS | AUDIO_EXTS | TEXT_EXTS
-CACHE_SIZE       = 5
-QUICK_LABEL_NAME = 'system_label_meta_txt'
+MEDIA_FILE_EXTS  = IMAGE_EXTS | VIDEO_EXTS | AUDIO_EXTS | TEXT_EXTS
+CACHE_SIZE        = 5
+DIR_MODE          = cli_args.dir
+QUICK_LABEL_NAME  = 'system_label_meta_txt'
+DIR_LABEL_NAME    = 'system_label_dir_meta_txt'
 
 # ─── Flask 與全域狀態 ───────────────────────────────────────────────────
 app       = Flask(__name__, static_folder='static', static_url_path='/static')
-DATA_ROOT = Path(sys.argv[1]).expanduser().resolve()
+DATA_ROOT = Path(cli_args.dataset_path).expanduser().resolve()
 INDEX: list[dict] = []                      # [{id, media, annos}]
 IMG_CACHE: OrderedDict[Path, bytes] = OrderedDict()
 
@@ -65,10 +75,26 @@ def build_index(root: Path):
                 **{e:3 for e in TEXT_EXTS}}
         media = sorted(media_candidates, key=lambda f: prio[f.suffix.lower()])[0]
 
-        INDEX.append({'id': data_id, 'media': media, 'annos': annos})
+        rel_media = media.relative_to(root)
+        dir_name  = rel_media.parts[0] if len(rel_media.parts) > 1 else ''
+
+        INDEX.append({'id': data_id,
+                      'media': media,
+                      'annos': annos,
+                      'dir'  : dir_name})
 
 build_index(DATA_ROOT)
 TOTAL = len(INDEX)
+
+# 依據第一層資料夾建立索引（dir -> 首張 idx）
+DIR_FIRST_IDX: dict[str, int] = {}
+DIR_ORDER: list[str] = []
+for i, ent in enumerate(INDEX):
+    d = ent['dir']
+    if d not in DIR_FIRST_IDX:
+        DIR_FIRST_IDX[d] = i
+        DIR_ORDER.append(d)
+
 
 # ─── 快取 ──────────────────────────────────────────────────────────────
 def preload(idx: int):
@@ -83,7 +109,7 @@ def preload(idx: int):
 # ─── API ──────────────────────────────────────────────────────────────
 @app.route('/')
 def home():
-    return render_template('index.html', total=TOTAL)
+    return render_template('index.html', total=TOTAL, dir_mode=DIR_MODE)
 
 @app.route('/api/item/<int:idx>')
 def api_item(idx: int):
@@ -104,14 +130,34 @@ def api_item(idx: int):
             txt = ''
         annos.append({'filename': str(f.relative_to(DATA_ROOT)), 'content': txt})
 
+    dir_name = ent['dir']
+    dir_path = DATA_ROOT / dir_name if dir_name else DATA_ROOT
+    dir_label = ''
+    dl_file = dir_path / DIR_LABEL_NAME
+    if dl_file.exists():
+        try:
+            dir_label = dl_file.read_text(encoding='utf-8', errors='ignore').strip()
+        except Exception:
+            dir_label = ''
+
+    dpos = DIR_ORDER.index(dir_name)
+    prev_dir = DIR_ORDER[(dpos - 1) % len(DIR_ORDER)]
+    next_dir = DIR_ORDER[(dpos + 1) % len(DIR_ORDER)]
+    dir_prev_idx = DIR_FIRST_IDX[prev_dir]
+    dir_next_idx = DIR_FIRST_IDX[next_dir]
+
     preload(idx)
     return jsonify({
-        'idx'        : idx,
-        'id'         : ent['id'],
-        'media_url'  : f'/file/{fp.relative_to(DATA_ROOT)}',
-        'media_kind' : kind,
-        'media_name' : str(fp.relative_to(DATA_ROOT)),
-        'annotations': annos
+        'idx'         : idx,
+        'id'          : ent['id'],
+        'media_url'   : f'/file/{fp.relative_to(DATA_ROOT)}',
+        'media_kind'  : kind,
+        'media_name'  : str(fp.relative_to(DATA_ROOT)),
+        'annotations' : annos,
+        'dir_name'    : dir_name,
+        'dir_label'   : dir_label,
+        'dir_prev_idx': dir_prev_idx,
+        'dir_next_idx': dir_next_idx
     })
 
 @app.route('/api/item/<int:idx>', methods=['POST'])
@@ -131,10 +177,15 @@ def api_save(idx: int):
     # 2. 快速標籤
     quick = (payload.get('quick_label') or '').strip()
     if quick:
-        qpath = DATA_ROOT / f'{ent["id"]}.{QUICK_LABEL_NAME}'
-        qpath.write_text(quick+'\n', encoding='utf-8')
-        if qpath not in ent['annos']:
-            ent['annos'].append(qpath)
+        if DIR_MODE:
+            dpath = DATA_ROOT / (ent['dir'] or '')
+            qpath = dpath / DIR_LABEL_NAME
+            qpath.write_text(quick + '\n', encoding='utf-8')
+        else:
+            qpath = DATA_ROOT / f'{ent["id"]}.{QUICK_LABEL_NAME}'
+            qpath.write_text(quick + '\n', encoding='utf-8')
+            if qpath not in ent['annos']:
+                ent['annos'].append(qpath)
 
     return jsonify({'status': 'ok'})
 
@@ -151,4 +202,6 @@ def serve_file(fname):
 if __name__ == '__main__':
     print(f'📂 Dataset: {DATA_ROOT}')
     print(f'🔢 Total  : {TOTAL} items')
+    if DIR_MODE:
+        print('📁 Dir mode enabled')
     app.run(host='0.0.0.0', port=49145, threaded=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,10 @@
    </div>
   </div>
 
-  <script>const TOTAL={{ total }};</script>
+  <script>
+    const TOTAL = {{ total }};
+    const DIR_MODE = {{ 'true' if dir_mode else 'false' }};
+  </script>
   <script src="/static/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add optional `--dir` argument to enable directory labeling
- store label per directory via `system_label_dir_meta_txt`
- navigate folders with up/down arrow keys in dir mode
- disable editing of `system_label_meta_txt` files when dir mode is on
- document new usage and keyboard shortcuts
- parse CLI arguments with `argparse`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6845a455de28832091e7021896d077ed