### PR TITLE
Add template configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ python app.py -h
 
 ## 模板設定範例
 
-提供 `--template` 參數時，程式會依照 JSON/YAML 內容決定註解排序、唯讀欄位以及額外函式。以下為 `examples/template.demo.json` 範例：
+提供 `--template` 參數時，程式會依照 JSON/YAML 內容決定註解排序、唯讀欄位以及額外函式。函式結果會以二欄表格呈現，滑鼠移至值欄可檢視完整內容。以下為 `examples/template.demo.json` 範例：
 
 ```json
 {
-  "ordering": ["caption\\d+_txt", "OCR_json", "OCR_txt"],
+  "ordering": ["caption\\d+_txt", "OCR_json", "OCR_txt", "meta_json"],
   "annotations": {
     "caption\\d+_txt": {
       "readonly": false
@@ -117,6 +117,14 @@ python app.py -h
       "readonly": true,
       "functions": [
         {"name": "Character name", "filter": "Character name :"}
+      ]
+    }
+    , "meta_json": {
+      "readonly": true,
+      "functions": [
+        {"name": "first 10 characters", "filter": "data['author']['nick'][:10]"},
+        {"name": "describe", "filter": "data['author']['description']"},
+        {"name": "describe_post", "filter": "data['content']"}
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -96,3 +96,38 @@ python app.py -h
 
 
 
+## 模板設定範例
+
+提供 `--template` 參數時，程式會依照 JSON/YAML 內容決定註解排序、唯讀欄位以及額外函式。以下為 `examples/template.demo.json` 範例：
+
+```json
+{
+  "ordering": ["caption\\d+_txt", "OCR_json", "OCR_txt"],
+  "annotations": {
+    "caption\\d+_txt": {
+      "readonly": false
+    },
+    "OCR_json": {
+      "readonly": true,
+      "functions": [
+        {"name": "first 10 characters", "filter": "data['result'][0]['text'][:10]"}
+      ]
+    },
+    "OCR_txt": {
+      "readonly": true,
+      "functions": [
+        {"name": "Character name", "filter": "Character name :"}
+      ]
+    }
+  }
+}
+```
+
+啟動時帶入：
+
+```bash
+python app.py /data/images --template examples/template.demo.json
+```
+
+完成後，`caption2_txt` 可直接編輯，`OCR_json` 與 `OCR_txt` 則僅顯示對應函式摘要且禁止修改。
+

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ python app.py /data/images --dir        # 以資料夾為單位標註
 # 進入資料夾模式時，命令列與頁面右上會顯示藍色 DIR MODE 標示
 # 啟用除錯標籤
 python app.py /data/images --debug
+# 套用顯示樣板 (JSON/YAML)
+python app.py /data/images --template config.json
 # 查看所有選項
 python app.py -h
 # 伺服器監聽 http://0.0.0.0:{port}

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ python app.py -h
 
 ```json
 {
-  "ordering": ["caption\\d+_txt", "OCR_json", "OCR_txt", "meta_json"],
+  "ordering": ["meta_json", "WD14_txt", "caption\\d+_txt"],
   "annotations": {
     "caption\\d+_txt": {
       "readonly": false
@@ -138,4 +138,7 @@ python app.py /data/images --template examples/template.demo.json
 ```
 
 完成後，`caption2_txt` 可直接編輯，`OCR_json` 與 `OCR_txt` 則僅顯示對應函式摘要且禁止修改。
+
+若有標註檔未在模板設定中出現，頁面會隱藏之並於右上角顯示隱藏數量。預設排序規則為
+`meta_json`、`WD14_txt`、`caption\d+_txt`，其餘依字母順序排列。
 

--- a/app.py
+++ b/app.py
@@ -200,7 +200,8 @@ def api_item(idx: int):
         readonly = rule['readonly'] if rule else False
         funcs = []
         if rule and rule['functions']:
-            is_json = f.suffix.lower() in {'.json', '.yaml', '.yml', '.json5'}
+            ann_ext = '.' + name_part.rsplit('_', 1)[-1].lower()
+            is_json = ann_ext in {'.json', '.yaml', '.yml', '.json5'}
             data_obj = None
             if is_json:
                 try:

--- a/app.py
+++ b/app.py
@@ -215,6 +215,7 @@ def api_item(idx: int):
             for fc in rule['functions']:
                 val = ''
                 expr = fc.get('filter', '')
+                highlight = ''
                 if is_json and data_obj is not None:
                     try:
                         val = str(eval(expr, {}, {'data': data_obj}))
@@ -224,8 +225,11 @@ def api_item(idx: int):
                     for ln in lines:
                         if expr in ln:
                             val = ln
+                            highlight = expr
                             break
-                funcs.append({'name': fc.get('name', ''), 'value': val})
+                funcs.append({'name': fc.get('name', ''),
+                              'value': val,
+                              'highlight': highlight})
 
         annos.append({'filename': str(f.relative_to(DATA_ROOT)),
                       'content': txt,

--- a/examples/template.demo.json
+++ b/examples/template.demo.json
@@ -1,0 +1,24 @@
+{
+  "ordering": [
+    "caption\\d+_txt",
+    "OCR_json",
+    "OCR_txt"
+  ],
+  "annotations": {
+    "caption\\d+_txt": {
+      "readonly": false
+    },
+    "OCR_json": {
+      "readonly": true,
+      "functions": [
+        {"name": "first 10 characters", "filter": "data['result'][0]['text'][:10]"}
+      ]
+    },
+    "OCR_txt": {
+      "readonly": true,
+      "functions": [
+        {"name": "Character name", "filter": "Character name :"}
+      ]
+    }
+  }
+}

--- a/examples/template.demo.json
+++ b/examples/template.demo.json
@@ -2,7 +2,8 @@
   "ordering": [
     "caption\\d+_txt",
     "OCR_json",
-    "OCR_txt"
+    "OCR_txt",
+    "meta_json"
   ],
   "annotations": {
     "caption\\d+_txt": {
@@ -18,6 +19,14 @@
       "readonly": true,
       "functions": [
         {"name": "Character name", "filter": "Character name :"}
+      ]
+    },
+    "meta_json": {
+      "readonly": true,
+      "functions": [
+        {"name": "first 10 characters", "filter": "data['author']['nick'][:10]"},
+        {"name": "describe", "filter": "data['author']['description']"},
+        {"name": "describe_post", "filter": "data['content']"}
       ]
     }
   }

--- a/examples/template.demo.json
+++ b/examples/template.demo.json
@@ -1,9 +1,8 @@
 {
   "ordering": [
-    "caption\\d+_txt",
-    "OCR_json",
-    "OCR_txt",
-    "meta_json"
+    "meta_json",
+    "WD14_txt",
+    "caption\\d+_txt"
   ],
   "annotations": {
     "caption\\d+_txt": {

--- a/static/main.js
+++ b/static/main.js
@@ -84,7 +84,8 @@ function render(d) {
     h4.textContent = a.filename;
     blk.appendChild(h4);
 
-    if (a.functions && a.functions.length) {
+    const hasFunc = a.functions && a.functions.length;
+    if (hasFunc) {
       const tbl = document.createElement('table');
       tbl.className = 'anno-func-table';
       a.functions.forEach(fn => {
@@ -112,14 +113,16 @@ function render(d) {
       blk.appendChild(tbl);
     }
 
-    const ta = document.createElement('textarea');
-    ta.value = a.content;
-    ta.dataset.filename = a.filename;
-    if (a.filename.endsWith('.system_label_meta_txt') || a.readonly) {
-      ta.disabled = true;
-      ta.classList.add('readonly');
+    if (!hasFunc) {
+      const ta = document.createElement('textarea');
+      ta.value = a.content;
+      ta.dataset.filename = a.filename;
+      if (a.filename.endsWith('.system_label_meta_txt') || a.readonly) {
+        ta.disabled = true;
+        ta.classList.add('readonly');
+      }
+      blk.appendChild(ta);
     }
-    blk.appendChild(ta);
 
     annoDiv.appendChild(blk);
   });
@@ -130,6 +133,14 @@ function render(d) {
   const quickBox = document.getElementById('quick-label');
   quickBox.value = quickInit;
   quickBox.focus();
+
+  const hLbl = document.getElementById('hidden-label');
+  if (d.hidden_count && d.hidden_count > 0) {
+    hLbl.textContent = `HIDDEN ${d.hidden_count}`;
+    hLbl.style.display = 'block';
+  } else {
+    hLbl.style.display = 'none';
+  }
 }
 
 /* ---------------- 鍵盤事件 ---------------- */

--- a/static/main.js
+++ b/static/main.js
@@ -89,11 +89,24 @@ function render(d) {
       tbl.className = 'anno-func-table';
       a.functions.forEach(fn => {
         const tr = document.createElement('tr');
-        const td = document.createElement('td');
-        td.textContent = fn.name;
-        if (fn.value)
-          td.title = fn.value;
-        tr.appendChild(td);
+        const nameTd = document.createElement('td');
+        nameTd.textContent = fn.name;
+        const valTd = document.createElement('td');
+        valTd.title = fn.value;
+        if (fn.highlight && fn.value.includes(fn.highlight)) {
+          const idx = fn.value.indexOf(fn.highlight);
+          valTd.appendChild(document.createTextNode(fn.value.slice(0, idx)));
+          const span = document.createElement('span');
+          span.className = 'func-match';
+          span.textContent = fn.highlight;
+          valTd.appendChild(span);
+          valTd.appendChild(document.createTextNode(
+            fn.value.slice(idx + fn.highlight.length)));
+        } else {
+          valTd.textContent = fn.value;
+        }
+        tr.appendChild(nameTd);
+        tr.appendChild(valTd);
         tbl.appendChild(tr);
       });
       blk.appendChild(tbl);

--- a/static/main.js
+++ b/static/main.js
@@ -84,11 +84,27 @@ function render(d) {
     h4.textContent = a.filename;
     blk.appendChild(h4);
 
+    if (a.functions && a.functions.length) {
+      const tbl = document.createElement('table');
+      tbl.className = 'anno-func-table';
+      a.functions.forEach(fn => {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.textContent = fn.name;
+        if (fn.value)
+          td.title = fn.value;
+        tr.appendChild(td);
+        tbl.appendChild(tr);
+      });
+      blk.appendChild(tbl);
+    }
+
     const ta = document.createElement('textarea');
     ta.value = a.content;
     ta.dataset.filename = a.filename;
-    if (a.filename.endsWith('.system_label_meta_txt')) {
+    if (a.filename.endsWith('.system_label_meta_txt') || a.readonly) {
       ta.disabled = true;
+      ta.classList.add('readonly');
     }
     blk.appendChild(ta);
 

--- a/static/style.css
+++ b/static/style.css
@@ -17,7 +17,8 @@ html,body{margin:0;height:100%;font-family:Arial,Helvetica,sans-serif;}
 .anno-block textarea{width:100%;height:120px;resize:vertical;}
 .anno-block textarea.readonly{background:#e0f0ff;}
 .anno-func-table{width:100%;font-size:12px;margin:4px 0;}
-.anno-func-table td{padding:2px 4px;background:#f0f0f0;}
+.anno-func-table td{padding:2px 4px;background:#f0f0f0;vertical-align:top;}
+.func-match{color:#c00;font-weight:bold;}
 #quick-label{width:100%;height:40px;margin-top:8px;font-size:18px;}
 #quick-name{margin:0 0 6px 0;font-weight:bold;}
 #debug-label{position:fixed;top:0;right:0;background:#c00;color:#fff;

--- a/static/style.css
+++ b/static/style.css
@@ -25,3 +25,5 @@ html,body{margin:0;height:100%;font-family:Arial,Helvetica,sans-serif;}
              padding:4px 8px;font-weight:bold;z-index:1000;}
 #dir-label{position:fixed;top:32px;right:0;background:#06c;color:#fff;
            padding:4px 8px;font-weight:bold;z-index:1000;}
+#hidden-label{position:fixed;top:64px;right:0;background:#555;color:#fff;
+             padding:4px 8px;z-index:1000;display:none;}

--- a/static/style.css
+++ b/static/style.css
@@ -15,6 +15,9 @@ html,body{margin:0;height:100%;font-family:Arial,Helvetica,sans-serif;}
 #right{width:40%;padding:10px;box-sizing:border-box;overflow-y:auto;background:#f8f8f8;}
 .anno-block{margin-bottom:16px;}
 .anno-block textarea{width:100%;height:120px;resize:vertical;}
+.anno-block textarea.readonly{background:#e0f0ff;}
+.anno-func-table{width:100%;font-size:12px;margin:4px 0;}
+.anno-func-table td{padding:2px 4px;background:#f0f0f0;}
 #quick-label{width:100%;height:40px;margin-top:8px;font-size:18px;}
 #quick-name{margin:0 0 6px 0;font-weight:bold;}
 #debug-label{position:fixed;top:0;right:0;background:#c00;color:#fff;

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,7 @@
 <body>
   {% if debug_mode %}<div id="debug-label">DEBUG</div>{% endif %}
   {% if dir_mode %}<div id="dir-label">DIR MODE</div>{% endif %}
+  <div id="hidden-label"></div>
   <div id="page-nav">
     <form id="page-form">
       <input id="page-input" type="number" min="1" value="1"/> / <span id="page-total"></span>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,7 @@
     const TOTAL = {{ total }};
     const DIR_MODE = {{ 'true' if dir_mode else 'false' }};
     const DEBUG_MODE = {{ 'true' if debug_mode else 'false' }};
+    const TEMPLATE_CONFIG = {{ template|tojson }};
   </script>
   <script src="/static/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add `--template` CLI option
- parse template JSON/YAML into `TEMPLATE_CONFIG`
- sort annotation files by configured ordering
- expose template config in API responses and index page

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fe3df91c8320884613218acbb2e8